### PR TITLE
Disable spell check to suppress red squiggles

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,7 +163,7 @@ function invert() {
 </script>
 </head>
 <body>
-<div id="plaintext-wrapper"><textarea id="plaintext"></textarea></div>
+<div id="plaintext-wrapper"><textarea id="plaintext" spellcheck="false"></textarea></div>
 <div id="nav"><span class="nav-default"><a class="nav-left" href="https://github.com/topaz/paste">[github]</a><a class="nav-left" onclick="invert()">[invert colors]</a><a onclick="url_generate('raw')">[generate url]</a><a onclick="url_generate('markdown')">[generate markdown link]</a></span><span class="nav-text-offer"><input id="text-offer-value"/><a onclick="text_offer_copy()">[copy]</a><a onclick="text_offer_cancel()">[cancel]</a></span></div>
 </body>
 </html>


### PR DESCRIPTION
Hi Topaz,

Awesome tool, thanks for that!

I find that Firefox pollutes the text with red squiggles because you're using a `textarea`. This PR adds an attribute to the `textarea` that turns spellcheck off, hiding the squiggles from view.

It works on my own machine - have not tested it but [according to MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/spellcheck) it's supported in all modern browsers.

Let me know if there's anything I can do to improve this PR.

Toon